### PR TITLE
feat: add throttling configuration with NestJS Throttler module

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,5 @@
 TATUM_ETHEREUM_SEPOLIA_API_KEY=t-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TATUM_ETHEREUM_MAINNET_API_KEY=t-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+PORT=4000
+THROTTLER_TTL=60000
+THROTTLER_LIMIT=5

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/config": "^4.0.0",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/throttler": "^6.4.0",
         "@tatumio/tatum": "^4.2.45",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
@@ -2410,6 +2411,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.4.0.tgz",
+      "integrity": "sha512-osL67i0PUuwU5nqSuJjtUJZMkxAnYB4VldgYUMGzvYRJDCqGRFMWbsbzm/CkUtPLRL30I8T74Xgt/OQxnYokiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "@nestjs/config": "^4.0.0",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/throttler": "^6.4.0",
     "@tatumio/tatum": "^4.2.45",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { BalanceModule } from './balance/balance.module';
 import { ConfigModule } from '@nestjs/config';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 
 @Module({
   imports: [
@@ -8,6 +10,18 @@ import { ConfigModule } from '@nestjs/config';
     ConfigModule.forRoot({
       isGlobal: true, // Makes .env available everywhere
     }),
+    ThrottlerModule.forRoot([
+      {
+        ttl: Number(process.env.THROTTLER_TTL) || 60000, // in milliseconds
+        limit: Number(process.env.THROTTLER_LIMIT) || 5, // requests within the TTL
+      },
+    ]),
+  ],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard, // Apply Throttler Guard globally
+    },
   ],
 })
 export class AppModule {}


### PR DESCRIPTION
### Summary
- Added global request throttling to protect the backend from excessive API requests.
- Applied `ThrottlerGuard` globally to enforce rate limits.

### Changes
- Configured `ThrottlerModule` globally with:
  - **TTL**: `60 seconds`
  - **Limit**: `5 requests per client`
- Allowed rate limit configuration via `.env`:
  - `THROTTLER_TTL=60000`
  - `THROTTLER_LIMIT=5`
- Ensured all API endpoints are protected without modifying individual controllers.

### Testing
- Verified that requests exceeding the limit return `429 Too Many Requests`.
- Ensured requests reset after TTL expires.
- Tested with multiple clients to confirm rate limits apply correctly.

### Next Steps
- Monitor API usage and adjust limits if needed.
